### PR TITLE
Fix build error in marketplace feed

### DIFF
--- a/lib/presentation/home_marketplace_feed/home_marketplace_feed.dart
+++ b/lib/presentation/home_marketplace_feed/home_marketplace_feed.dart
@@ -159,7 +159,7 @@ class _HomeMarketplaceFeedState extends State<HomeMarketplaceFeed>
         final favorites = await _favoriteService.getUserFavorites();
         setState(() {
            _favoriteListings = Set<String>.from(
-              favorites.map((fav) => fav['listing_id']));
+              favorites.map((fav) => fav['listing_id'].toString()));
         });
       }
     } catch (error) {


### PR DESCRIPTION
Convert `listing_id` to string when loading favorites to resolve type mismatch.