### PR TITLE
Build Android application with Flutter

### DIFF
--- a/lib/presentation/home_marketplace_feed/home_marketplace_feed.dart
+++ b/lib/presentation/home_marketplace_feed/home_marketplace_feed.dart
@@ -214,7 +214,7 @@ Future<void> _loadInitialData() async {
           final serverCat = categories.firstWhere(
             (cat) => cat['name'].toString().toLowerCase() == 
                      defaultCat['name'].toString().toLowerCase(),
-            orElse: () => null,
+            orElse: () => <String, dynamic>{},
           );
           
           return {

--- a/lib/utils/category_service.dart
+++ b/lib/utils/category_service.dart
@@ -30,7 +30,7 @@ class CategoryService {
       final response = await client
           .from(_categoriesTable)
           .select('*')
-          .is_('parent_id', null)
+          .eq('parent_id', null)
           .order('sort_order', ascending: true);
 
       return List<Map<String, dynamic>>.from(response);

--- a/lib/utils/favorite_service.dart
+++ b/lib/utils/favorite_service.dart
@@ -253,7 +253,7 @@ class FavoriteService {
             category:categories(name),
             seller:user_profiles(full_name, avatar_url)
           ''')
-          .in('id', topListingIds)
+          .in_('id', topListingIds)
           .eq('status', 'active');
 
       return List<Map<String, dynamic>>.from(listingsResponse);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   connectivity_plus: ^5.0.2
   retrofit: ^4.0.3
   internet_connection_checker: ^1.0.0+1
+  postgrest: ^2.4.2
 
   # 💾 STORAGE & PERSISTENCE
   shared_preferences: ^2.2.2
@@ -55,7 +56,7 @@ dependencies:
   photo_view: ^0.14.0
   flutter_image_compress: ^2.1.0
   video_player: ^2.8.1
-  file_picker: ^6.1.1
+  file_picker: ^10.2.0
 
   # 📍 LOCATION & MAPS
   google_maps_flutter: ^2.5.0


### PR DESCRIPTION
Fix build errors by updating `postgrest` API usage, resolving nullability, and upgrading dependencies.

The build failed due to `postgrest` method renames (`.is_` to `.eq`, `.in` to `.in_`), a Dart keyword conflict (`in`), and a nullability issue (`orElse: () => null` for non-nullable return types). This PR addresses these by updating the code and relevant dependencies.