### PR TITLE
Fix Android build errors

### DIFF
--- a/lib/utils/category_service.dart
+++ b/lib/utils/category_service.dart
@@ -30,7 +30,7 @@ class CategoryService {
       final response = await client
           .from(_categoriesTable)
           .select('*')
-          .isFilter('parent_id', 'is', null)
+          .eq('parent_id', null)
           .order('sort_order', ascending: true);
 
       return List<Map<String, dynamic>>.from(response);


### PR DESCRIPTION
Fix Android build failure by using `eq` for Supabase null queries.

The `isFilter` method was incorrectly used with three arguments, leading to a build error. `eq` is the correct Supabase method for checking null values.