### PR TITLE
Fix errors in the project

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,6 @@
 
     <application
         android:label="khilonjiya.com"
-        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
         android:supportsRtl="true"


### PR DESCRIPTION
Remove `android:name="${applicationName}"` from `AndroidManifest.xml` to fix Android v1 embedding build errors.

The undefined `${applicationName}` attribute caused the build system to incorrectly use or fall back to the deprecated Android v1 embedding, leading to build failures. Removing it ensures the default Flutter Application class is used, compatible with v2 embedding.