### PR TITLE
Build debug APK with errors

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,8 +21,7 @@
         android:allowBackup="true"
         android:supportsRtl="true"
         android:theme="@style/LaunchTheme"
-        android:usesCleartextTraffic="true"
-        android:name="${applicationName}">
+        android:usesCleartextTraffic="true">
         
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Remove `android:name="${applicationName}"` from AndroidManifest.xml to resolve Android v1 embedding build error.