### PR TITLE
Build Android application with Flutter

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,13 +1,11 @@
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8.fullMode=false
 kotlin.mpp.stability.nowarn=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
-android.enableR8=false
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Remove deprecated `android.enableR8` properties to fix Android build failure.