### PR TITLE
Resolve build errors from error.txt

### DIFF
--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -15,7 +15,7 @@ export 'package:intl/intl.dart';
 export 'package:url_launcher/url_launcher.dart';
 export 'package:http/http.dart';
 export 'package:sqflite/sqflite.dart';
-export 'package:path/path.dart';
+// export 'package:path/path.dart'; // Removed to prevent Context/BuildContext conflict. Import directly where needed.
 export 'package:flutter_local_notifications/flutter_local_notifications.dart';
 export 'package:permission_handler/permission_handler.dart';
 export 'package:supabase_flutter/supabase_flutter.dart';
@@ -27,7 +27,7 @@ export '../widgets/custom_image_widget.dart';
 export '../widgets/custom_error_widget.dart';
 export '../theme/app_theme.dart';
 export '../utils/supabase_service.dart';
-export '../utils/auth_service.dart';
+// export '../utils/auth_service.dart'; // Removed to prevent AuthException export conflict. Import directly where needed.
 export '../utils/listing_service.dart';
 export '../utils/category_service.dart';
 export '../utils/favorite_service.dart';

--- a/lib/presentation/favorites_and_saved_items/favorites_and_saved_items.dart
+++ b/lib/presentation/favorites_and_saved_items/favorites_and_saved_items.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sizer/sizer.dart';
 
-import '../../core/app_export.dart';
+import '../../utils/auth_service.dart';
 import './widgets/collection_folder_widget.dart';
 import './widgets/favorite_item_card_widget.dart';
 import './widgets/price_alert_dialog_widget.dart';

--- a/lib/presentation/onboarding_tutorial/onboarding_tutorial.dart
+++ b/lib/presentation/onboarding_tutorial/onboarding_tutorial.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:sizer/sizer.dart';
 
-import '../../core/app_export.dart';
+import '../../utils/auth_service.dart';
 import './widgets/onboarding_page_widget.dart';
 import './widgets/page_indicator_widget.dart';
 

--- a/lib/presentation/splash_screen/splash_screen.dart
+++ b/lib/presentation/splash_screen/splash_screen.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
+import '../../utils/auth_service.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({Key? key}) : super(key: key);

--- a/lib/presentation/user_profile/user_profile.dart
+++ b/lib/presentation/user_profile/user_profile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sizer/sizer.dart';
 
-import '../../core/app_export.dart';
+import '../../utils/auth_service.dart';
 import './widgets/account_settings_section_widget.dart';
 import './widgets/favorites_section_widget.dart';
 import './widgets/my_listings_section_widget.dart';


### PR DESCRIPTION
Resolve build errors by removing conflicting exports from `app_export.dart` and updating direct imports.

The `error.txt` indicated conflicts with `Context`/`BuildContext` and `AuthException`. These were caused by `package:path/path.dart` and `auth_service.dart` being exported through `app_export.dart`, leading to name clashes with Flutter's `BuildContext` and Supabase's `AuthException` respectively. Removing these exports and updating direct imports resolves these build issues.