### PR TITLE
Fix Android build compilation errors

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -17,9 +17,10 @@ workflows:
           flutter clean
           flutter pub cache repair
           flutter pub get
+          flutter analyze
       - name: Build Debug APK
         script: |
-          flutter build apk --debug || flutter build apk --debug -v
+          flutter build apk --debug -v
     artifacts:
       - build/app/outputs/flutter-apk/app-debug.apk
 


### PR DESCRIPTION
Update Codemagic workflow to include `flutter analyze` and verbose build logs.

The previous Android build was failing with a generic error, and these changes provide more diagnostic information to pinpoint the root cause by running `flutter analyze` and enabling verbose output for the build command.