### PR TITLE
Fix Android build failure issues

### DIFF
--- a/ANDROID_BUILD_FIXES.md
+++ b/ANDROID_BUILD_FIXES.md
@@ -1,0 +1,100 @@
+# Android Build Memory Optimization Fixes
+
+## Problem
+The Android build was failing with a Java heap space error during the desugaring process:
+```
+Execution failed for task ':app:desugarDebugFileDependencies'.
+> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
+   > Failed to transform x86_debug-1.0.0-72f2b18bb094f92f62a3113a8075240ebb59affa.jar
+      > Java heap space
+```
+
+## Solutions Applied
+
+### 1. Increased Java Heap Memory
+- **File**: `android/gradle.properties`
+- **Change**: Increased heap size from 4GB to 8GB
+- **Change**: Increased MaxMetaspaceSize from 512MB to 1GB
+- **Added**: Parallel GC optimization flags
+
+```properties
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxGCPauseMillis=200 -Dfile.encoding=UTF-8
+```
+
+### 2. Added Build Performance Optimizations
+- **File**: `android/gradle.properties`
+- **Added**: Worker thread limit to prevent memory overload
+- **Added**: R8 and D8 optimization flags
+
+```properties
+org.gradle.workers.max=4
+android.enableR8.fullMode=false
+android.enableD8.desugaring=true
+android.enableD8.desugaring.artifacts=true
+```
+
+### 3. Enhanced App-Level Build Configuration
+- **File**: `android/app/build.gradle`
+- **Added**: DEX options with memory optimization
+- **Added**: Disabled pre-dexing to reduce memory usage
+
+```gradle
+dexOptions {
+    javaMaxHeapSize "4g"
+    preDexLibraries = false
+}
+```
+
+### 4. Updated CI/CD Configuration
+- **File**: `codemagic.yaml`
+- **Increased**: Build duration limits from 60 to 120 minutes
+- **Added**: Memory optimization environment variables for all build workflows
+
+```yaml
+export GRADLE_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC"
+```
+
+### 5. Created Local Build Script
+- **File**: `build_android.sh`
+- **Purpose**: Provides memory-optimized local build process
+- **Usage**: `./build_android.sh`
+
+## How to Use
+
+### For Local Development
+1. Use the provided build script:
+   ```bash
+   ./build_android.sh
+   ```
+
+2. Or manually set environment variables:
+   ```bash
+   export GRADLE_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC"
+   flutter build apk --debug
+   ```
+
+### For CI/CD
+The `codemagic.yaml` file has been updated with memory optimization for all build workflows.
+
+## Additional Recommendations
+
+1. **Clean builds regularly**: Run `flutter clean` before builds
+2. **Monitor memory usage**: Use `flutter doctor -v` to check system resources
+3. **Update Flutter**: Ensure you're using the latest stable Flutter version
+4. **Consider build variants**: Use specific build types to reduce memory usage
+
+## Troubleshooting
+
+If you still encounter memory issues:
+
+1. **Increase heap size further**: Modify `-Xmx8g` to `-Xmx12g` in `gradle.properties`
+2. **Reduce parallel workers**: Change `org.gradle.workers.max=4` to `org.gradle.workers.max=2`
+3. **Disable parallel builds**: Set `org.gradle.parallel=false` temporarily
+4. **Check system resources**: Ensure your build machine has sufficient RAM (recommended: 16GB+)
+
+## Files Modified
+- `android/gradle.properties`
+- `android/app/build.gradle`
+- `android/build.gradle`
+- `codemagic.yaml`
+- `build_android.sh` (new)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-coreLibraryDesugaringEnabled true
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -75,6 +75,12 @@ coreLibraryDesugaringEnabled true
     lintOptions {
         disable 'InvalidPackage'
         checkReleaseBuilds false
+    }
+    
+    // Memory optimization for desugaring
+    dexOptions {
+        javaMaxHeapSize "4g"
+        preDexLibraries = false
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,14 @@ allprojects {
         google()
         mavenCentral()
     }
+    
+    // Memory optimization for all projects
+    project.configurations.all {
+        resolutionStrategy {
+            cacheChangingModulesFor 0, 'seconds'
+            cacheDynamicVersionsFor 0, 'seconds'
+        }
+    }
 }
 
 rootProject.buildDir = '../build'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,7 +1,7 @@
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.mpp.stability.nowarn=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxGCPauseMillis=200 -Dfile.encoding=UTF-8
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
@@ -9,3 +9,8 @@ org.gradle.caching=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# Additional memory and performance optimizations
+org.gradle.workers.max=4
+android.enableR8.fullMode=false
+android.enableD8.desugaring=true
+android.enableD8.desugaring.artifacts=true

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Android Build Script with Memory Optimization
+echo "Starting Android build with memory optimization..."
+
+# Set memory optimization environment variables
+export GRADLE_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC -XX:MaxGCPauseMillis=200"
+export JAVA_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g"
+
+# Clean previous builds
+echo "Cleaning previous builds..."
+flutter clean
+
+# Get dependencies
+echo "Getting Flutter dependencies..."
+flutter pub get
+
+# Build Android APK with memory optimization
+echo "Building Android APK..."
+flutter build apk --debug --verbose
+
+echo "Build completed!"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,7 +1,7 @@
 workflows:
   build_apk_debug:
     name: Build Debug APK
-    max_build_duration: 60
+    max_build_duration: 120
     environment:
       flutter: stable
       xcode: latest
@@ -20,13 +20,14 @@ workflows:
           flutter pub get
       - name: Build Debug APK
         script: |
+          export GRADLE_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC"
           flutter build apk --debug -v --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
     artifacts:
       - build/app/outputs/flutter-apk/app-debug.apk
 
   build_apk_release:
     name: Build Release APK
-    max_build_duration: 60
+    max_build_duration: 120
     environment:
       flutter: stable
       xcode: latest
@@ -46,13 +47,14 @@ workflows:
           flutter pub get
       - name: Build Release APK
         script: |
+          export GRADLE_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC"
           flutter build apk --release --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
     artifacts:
       - build/app/outputs/flutter-apk/app-release.apk
 
   build_app_bundle:
     name: Build App Bundle
-    max_build_duration: 60
+    max_build_duration: 120
     environment:
       flutter: stable
       xcode: latest
@@ -71,6 +73,7 @@ workflows:
           flutter pub get
       - name: Build App Bundle
         script: |
+          export GRADLE_OPTS="-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC"
           flutter build appbundle --release --dart-define=SUPABASE_URL=$SUPABASE_URL --dart-define=SUPABASE_ANON_KEY=$SUPABASE_ANON_KEY
     artifacts:
       - build/app/outputs/bundle/release/app-release.aab


### PR DESCRIPTION
Implement memory optimizations for Android builds to resolve Java heap space errors.

The build was failing with a `Java heap space` error during the `desugarDebugFileDependencies` task, particularly during `JetifyTransform`. This PR increases Java heap memory, adds Gradle and DEX optimization flags, and updates CI/CD configurations to prevent out-of-memory issues.